### PR TITLE
Fix 73

### DIFF
--- a/forest-core/src/main/java/com/dtflys/forest/backend/httpclient/conn/ForestSSLConnectionFactory.java
+++ b/forest-core/src/main/java/com/dtflys/forest/backend/httpclient/conn/ForestSSLConnectionFactory.java
@@ -27,23 +27,30 @@ public class ForestSSLConnectionFactory implements LayeredConnectionSocketFactor
     }
 
     @Override
-    public Socket connectSocket(
-            final int connectTimeout,
-            final Socket socket,
-            final HttpHost host,
-            final InetSocketAddress remoteAddress,
-            final InetSocketAddress localAddress,
-            final HttpContext context) throws IOException {
-        ForestRequest request = getCurrentRequest(context);
+    public Socket connectSocket(final int connectTimeout, final Socket socket, final HttpHost host, final InetSocketAddress remoteAddress, final InetSocketAddress localAddress, final HttpContext context) throws IOException {
+        ForestRequest currentRequest = getCurrentRequest(context);
+        Socket connectSocket = getSslConnectionSocketFactory(currentRequest).connectSocket(connectTimeout, socket, host, remoteAddress, localAddress, context);
+        return connectSocket;
+    }
+
+    @Override
+    public Socket createLayeredSocket(Socket socket, String target, int port, HttpContext context) throws IOException {
+        ForestRequest currentRequest = getCurrentRequest(context);
+        Socket connectSocket = getSslConnectionSocketFactory(currentRequest).createLayeredSocket(socket, target, port, context);
+        return connectSocket;
+    }
+
+    /**
+     * 根据当前请求构建独立的SSLConnectionSocketFactory
+     *
+     * @param request 当前请求
+     * @return
+     */
+    private SSLConnectionSocketFactory getSslConnectionSocketFactory(ForestRequest request) {
         SSLSocketFactory sslSocketFactory = request.getSSLSocketFactory();
         SSLKeyStore keyStore = request.getKeyStore();
-        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(
-                sslSocketFactory,
-                keyStore == null ? null : keyStore.getProtocols(),
-                keyStore == null ? null : keyStore.getCipherSuites(),
-                request.hostnameVerifier());
-        Socket connectSocket = factory.connectSocket(connectTimeout, socket, host, remoteAddress, localAddress, context);
-        return connectSocket;
+        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(sslSocketFactory, keyStore == null ? null : keyStore.getProtocols(), keyStore == null ? null : keyStore.getCipherSuites(), request.hostnameVerifier());
+        return factory;
     }
 
     private ForestRequest getCurrentRequest(HttpContext context) {
@@ -54,10 +61,5 @@ public class ForestSSLConnectionFactory implements LayeredConnectionSocketFactor
         return (ForestRequest) request;
     }
 
-
-    @Override
-    public Socket createLayeredSocket(Socket socket, String target, int port, HttpContext context) {
-        return null;
-    }
 
 }

--- a/forest-core/src/test/java/com/dtflys/test/http/TestHttpClientHttpPorxy.java
+++ b/forest-core/src/test/java/com/dtflys/test/http/TestHttpClientHttpPorxy.java
@@ -1,0 +1,85 @@
+package com.dtflys.test.http;
+
+import com.dtflys.forest.annotation.Backend;
+import com.dtflys.forest.annotation.Get;
+import com.dtflys.forest.annotation.HTTPProxy;
+import com.dtflys.forest.backend.HttpBackend;
+import com.dtflys.forest.config.ForestConfiguration;
+import com.dtflys.forest.mock.MockServerRequest;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author tanglingyan[xiao4852@qq.com]
+ * @since 2022-06-04 10:57
+ */
+public class TestHttpClientHttpPorxy extends BaseClientTest {
+
+    private static ForestConfiguration configuration;
+    @Rule
+    public final MockWebServer server = new MockWebServer();
+    private final TestHttpClientHttpPorxyClient testHttpClientHttpPorxyClient;
+
+    public TestHttpClientHttpPorxy(HttpBackend backend) {
+        super(backend, configuration);
+        configuration.setVariableValue("port", server.getPort());
+        testHttpClientHttpPorxyClient = configuration.createInstance(TestHttpClientHttpPorxyClient.class);
+
+    }
+
+    @BeforeClass
+    public static void prepareClient() {
+        configuration = ForestConfiguration.createConfiguration();
+    }
+
+    public static MockServerRequest mockRequest(MockWebServer server) {
+        try {
+            RecordedRequest request = server.takeRequest();
+            return new MockServerRequest(request);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void afterRequests() {
+    }
+
+    /**
+     *
+     */
+    @Test
+    public void testHttpClientHttpPorxy() {
+//        server.enqueue(new MockResponse().setBody("{'flag':'ok'}"));
+//        //发送http请求
+//        testHttpClientHttpPorxyClient.testHttpPorxy();
+//        try {
+//            server.takeRequest();
+//        } catch (InterruptedException e) {
+//            e.printStackTrace();
+//        }
+
+        String text = testHttpClientHttpPorxyClient.testHttpPorxy();
+        //System.out.println(text);
+    }
+
+
+    /**
+     * http接口
+     *
+     * @author tanglingyan[xiao4852@qq.com]
+     * @since 2022-06-04 10:57
+     */
+    @HTTPProxy(host = "127.0.0.1", port = "8888")
+    public interface TestHttpClientHttpPorxyClient {
+        @Backend("httpclient")
+//        @Get("https://localhost:{port}")
+//        @Get("https:www.baidu.com")
+        @Get(url="https://10.34.1.170/",sslProtocol = "TLS")
+        String testHttpPorxy();
+    }
+
+}

--- a/forest-core/src/test/java/com/dtflys/test/http/TestHttpClientHttpPorxy.java
+++ b/forest-core/src/test/java/com/dtflys/test/http/TestHttpClientHttpPorxy.java
@@ -1,27 +1,29 @@
 package com.dtflys.test.http;
 
-import com.dtflys.forest.annotation.Backend;
 import com.dtflys.forest.annotation.Get;
 import com.dtflys.forest.annotation.HTTPProxy;
 import com.dtflys.forest.backend.HttpBackend;
 import com.dtflys.forest.config.ForestConfiguration;
-import com.dtflys.forest.mock.MockServerRequest;
 import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * @author tanglingyan[xiao4852@qq.com]
- * @since 2022-06-04 10:57
+ * @since 2022-06-09 14:29
  */
 public class TestHttpClientHttpPorxy extends BaseClientTest {
+
+    public final static String EXPECTED = "{\"status\":\"ok\"}";
+
 
     private static ForestConfiguration configuration;
     @Rule
     public final MockWebServer server = new MockWebServer();
-    private final TestHttpClientHttpPorxyClient testHttpClientHttpPorxyClient;
+
+    private TestHttpClientHttpPorxyClient testHttpClientHttpPorxyClient;
 
     public TestHttpClientHttpPorxy(HttpBackend backend) {
         super(backend, configuration);
@@ -35,35 +37,21 @@ public class TestHttpClientHttpPorxy extends BaseClientTest {
         configuration = ForestConfiguration.createConfiguration();
     }
 
-    public static MockServerRequest mockRequest(MockWebServer server) {
-        try {
-            RecordedRequest request = server.takeRequest();
-            return new MockServerRequest(request);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     @Override
     public void afterRequests() {
     }
 
     /**
-     *
+     * 测试http代理
      */
-    @Test
+    //由于需要代理依赖本地环境这里进行注释
+    //@Test
     public void testHttpClientHttpPorxy() {
-//        server.enqueue(new MockResponse().setBody("{'flag':'ok'}"));
-//        //发送http请求
-//        testHttpClientHttpPorxyClient.testHttpPorxy();
-//        try {
-//            server.takeRequest();
-//        } catch (InterruptedException e) {
-//            e.printStackTrace();
-//        }
-
+        //模拟https失败
+        //server.enqueue(new MockResponse().setBody(EXPECTED));
         String text = testHttpClientHttpPorxyClient.testHttpPorxy();
-        //System.out.println(text);
+        Assert.assertTrue(text != null && text.indexOf("百度一下，你就知道") != -1);
     }
 
 
@@ -71,14 +59,13 @@ public class TestHttpClientHttpPorxy extends BaseClientTest {
      * http接口
      *
      * @author tanglingyan[xiao4852@qq.com]
-     * @since 2022-06-04 10:57
+     * @since 2022-06-09 14:29
      */
     @HTTPProxy(host = "127.0.0.1", port = "8888")
     public interface TestHttpClientHttpPorxyClient {
-        @Backend("httpclient")
-//        @Get("https://localhost:{port}")
-//        @Get("https:www.baidu.com")
-        @Get(url="https://10.34.1.170/",sslProtocol = "TLS")
+        //@Backend("httpclient")
+        //@Get(url="https://127.0.0.1:{port}")
+        @Get(value = "https://www.baidu.com", sslProtocol = "TLS")
         String testHttpPorxy();
     }
 


### PR DESCRIPTION
解决使用@HTTPProxy注解对https请求设置http代理后出现java.lang.IllegalArgumentException:Socket may not be null