### PR TITLE
Fix 100

### DIFF
--- a/forest-core/src/main/java/com/dtflys/forest/http/ForestHeaderMap.java
+++ b/forest-core/src/main/java/com/dtflys/forest/http/ForestHeaderMap.java
@@ -37,7 +37,7 @@ public class ForestHeaderMap implements Map<String, String>, Cloneable {
 
     private final List<ForestHeader> headers;
 
-    private volatile ForestCookieHeader cookieHeader = null;
+    private ForestCookieHeader cookieHeader = null;
 
     private final List<ForestCookie> requestCookies = new LinkedList<>();
 
@@ -396,8 +396,9 @@ public class ForestHeaderMap implements Map<String, String>, Cloneable {
      */
     public void addCookie(ForestCookie cookie, boolean strict) {
         if (cookieHeader == null) {
-            cookieHeader = new ForestCookieHeader(hasURL);
-            if (cookieHeader.addCookie(cookie, strict)) {
+            ForestCookieHeader cookieHeaderTmp = new ForestCookieHeader(hasURL);
+            if (cookieHeaderTmp.addCookie(cookie, strict)) {
+                cookieHeader = cookieHeaderTmp;
                 addHeader(cookieHeader);
             }
         } else {

--- a/forest-core/src/test/java/com/dtflys/test/misc/HeaderTest.java
+++ b/forest-core/src/test/java/com/dtflys/test/misc/HeaderTest.java
@@ -36,7 +36,7 @@ public class HeaderTest extends TestCase {
     public void testAddCookie() {
         HasURL hasURL = () -> {
             try {
-                return new ForestURL(new URL("https://baidu.com"));
+                return new ForestURL(new URL("https://baidu.com/aaa"));
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }
@@ -53,7 +53,7 @@ public class HeaderTest extends TestCase {
         assertFalse(forestHeaderMap.containsKey("Cookie"));
 
 
-        String url1 = "https://baidu.com";
+        String url1 = "https://baidu.com/test";
         String setCookie1 = "foo=bar; max-age=" + maxAge.getSeconds();
         ForestCookie cookie1 = ForestCookie.parse(url1, setCookie1);
         forestHeaderMap.addCookie(cookie1);

--- a/forest-core/src/test/java/com/dtflys/test/misc/HeaderTest.java
+++ b/forest-core/src/test/java/com/dtflys/test/misc/HeaderTest.java
@@ -5,7 +5,6 @@ import com.dtflys.forest.http.ForestHeaderMap;
 import com.dtflys.forest.http.ForestURL;
 import com.dtflys.forest.http.HasURL;
 import junit.framework.TestCase;
-import org.junit.Test;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -34,7 +33,6 @@ public class HeaderTest extends TestCase {
      *
      * @author yangle94
      */
-    @Test
     public void testAddCookie() {
         HasURL hasURL = () -> {
             try {

--- a/forest-core/src/test/java/com/dtflys/test/misc/HeaderTest.java
+++ b/forest-core/src/test/java/com/dtflys/test/misc/HeaderTest.java
@@ -1,8 +1,15 @@
 package com.dtflys.test.misc;
 
+import com.dtflys.forest.http.ForestCookie;
 import com.dtflys.forest.http.ForestHeaderMap;
+import com.dtflys.forest.http.ForestURL;
+import com.dtflys.forest.http.HasURL;
 import junit.framework.TestCase;
+import org.junit.Test;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
 import java.util.List;
 
 public class HeaderTest extends TestCase {
@@ -22,4 +29,37 @@ public class HeaderTest extends TestCase {
         assertEquals("3", values.get(1));
     }
 
+    /**
+     * 测试添加cookie
+     *
+     * @author yangle94
+     */
+    @Test
+    public void testAddCookie() {
+        HasURL hasURL = () -> {
+            try {
+                return new ForestURL(new URL("https://baidu.com"));
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+        };
+        ForestHeaderMap forestHeaderMap = new ForestHeaderMap(hasURL);
+
+        Duration maxAge = Duration.ofSeconds(10L);
+        String url = "http://forest.dtflyx.com/docs";
+        String setCookie = "foo=bar; max-age=" + maxAge.getSeconds();
+        ForestCookie cookie = ForestCookie.parse(url, setCookie);
+
+        forestHeaderMap.addCookie(cookie);
+
+        assertFalse(forestHeaderMap.containsKey("Cookie"));
+
+
+        String url1 = "https://baidu.com";
+        String setCookie1 = "foo=bar; max-age=" + maxAge.getSeconds();
+        ForestCookie cookie1 = ForestCookie.parse(url1, setCookie1);
+        forestHeaderMap.addCookie(cookie1);
+
+        assertTrue(forestHeaderMap.containsKey("Cookie"));
+    }
 }


### PR DESCRIPTION
1. 纠正ForestHeaderMap.addCookie(ForestCookie cookie, boolean strict)方法某些情况下，会导致cookie丢失的问题
2. cookieHeader去除volatile修饰符