### PR TITLE
fix recursive call bug

### DIFF
--- a/forest-core/src/main/java/com/dtflys/forest/utils/ReflectUtils.java
+++ b/forest-core/src/main/java/com/dtflys/forest/utils/ReflectUtils.java
@@ -314,7 +314,7 @@ public class ReflectUtils {
      * @return {@code true}: 是Forest接口注解；{@code false}: 不是Forest接口注解
      */
     public static boolean isForestBaseAnnotation(Annotation annotation) {
-        return isForestBaseAnnotation(annotation);
+        return isForestBaseAnnotation(annotation.annotationType());
     }
 
     /**


### PR DESCRIPTION
## 问题说明
- `ReflectUtils.isForestBaseAnnotation`递归调用，导致`StackOverflowError`
```
    public static boolean isForestBaseAnnotation(Annotation annotation) {
        return isForestBaseAnnotation(annotation);
    }
```
## 解决方案
```
    public static boolean isForestBaseAnnotation(Annotation annotation) {
        return isForestBaseAnnotation(annotation.annotationType());
    }
```