### PR TITLE
新增多异步线程池的功能，请求时指定线程池名称

### DIFF
--- a/forest-core/src/main/java/com/dtflys/forest/annotation/Delete.java
+++ b/forest-core/src/main/java/com/dtflys/forest/annotation/Delete.java
@@ -75,6 +75,12 @@ public @interface Delete {
     boolean async() default false;
 
     /**
+     * 异步请求时，指定线程池的名称
+     * @return asyncPoolName
+     */
+    String asyncPoolName() default "";
+
+    /**
      * 请求超时时间, 单位为毫秒
      * @return 请求超时时间
      * @deprecated 请使用 {@link #connectTimeout()} 和 {@link #readTimeout()}

--- a/forest-core/src/main/java/com/dtflys/forest/annotation/Get.java
+++ b/forest-core/src/main/java/com/dtflys/forest/annotation/Get.java
@@ -75,6 +75,12 @@ public @interface Get {
     boolean async() default false;
 
     /**
+     * 异步请求时，指定线程池的名称
+     * @return asyncPoolName
+     */
+    String asyncPoolName() default "";
+
+    /**
      * 请求超时时间, 单位为毫秒
      * @return 请求超时时间
      * @deprecated 请使用 {@link #connectTimeout()} 和 {@link #readTimeout()}

--- a/forest-core/src/main/java/com/dtflys/forest/annotation/Patch.java
+++ b/forest-core/src/main/java/com/dtflys/forest/annotation/Patch.java
@@ -75,6 +75,12 @@ public @interface Patch {
     boolean async() default false;
 
     /**
+     * 异步请求时，指定线程池的名称
+     * @return asyncPoolName
+     */
+    String asyncPoolName() default "";
+
+    /**
      * 请求超时时间, 单位为毫秒
      * @return 请求超时时间
      * @deprecated 请使用 {@link #connectTimeout()} 和 {@link #readTimeout()}

--- a/forest-core/src/main/java/com/dtflys/forest/annotation/Post.java
+++ b/forest-core/src/main/java/com/dtflys/forest/annotation/Post.java
@@ -75,6 +75,12 @@ public @interface Post {
     boolean async() default false;
 
     /**
+     * 异步请求时，指定线程池的名称
+     * @return asyncPoolName
+     */
+    String asyncPoolName() default "";
+
+    /**
      * 请求超时时间, 单位为毫秒
      * @return 请求超时时间
      * @deprecated 请使用 {@link #connectTimeout()} 和 {@link #readTimeout()}

--- a/forest-core/src/main/java/com/dtflys/forest/annotation/Put.java
+++ b/forest-core/src/main/java/com/dtflys/forest/annotation/Put.java
@@ -75,6 +75,12 @@ public @interface Put {
     boolean async() default false;
 
     /**
+     * 异步请求时，指定线程池的名称
+     * @return asyncPoolName
+     */
+    String asyncPoolName() default "";
+
+    /**
      * 请求超时时间, 单位为毫秒
      * @return 请求超时时间
      * @deprecated 请使用 {@link #connectTimeout()} 和 {@link #readTimeout()}

--- a/forest-core/src/main/java/com/dtflys/forest/backend/AsyncHttpExecutor.java
+++ b/forest-core/src/main/java/com/dtflys/forest/backend/AsyncHttpExecutor.java
@@ -8,11 +8,10 @@ import com.dtflys.forest.http.ForestRequest;
 import com.dtflys.forest.http.ForestResponse;
 import com.dtflys.forest.http.ForestResponseFactory;
 import com.dtflys.forest.reflection.MethodLifeCycleHandler;
+import com.dtflys.forest.utils.StringUtils;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 /**
@@ -36,6 +35,7 @@ public class AsyncHttpExecutor<T> implements HttpExecutor {
     protected final ResponseHandler responseHandler;
 
 
+    private static final String DEFAULT_POOL_NAME = "default";
 
 
     /**
@@ -43,8 +43,9 @@ public class AsyncHttpExecutor<T> implements HttpExecutor {
      *
      * @return 最大异步线程数
      */
-    public static int getMaxAsyncThreadSize() {
-        return getMaxAsyncThreadSize(ForestConfiguration.configuration());
+    public static int getMaxAsyncThreadSize(String... asyncPoolName) {
+        String name = asyncPoolName == null || asyncPoolName.length == 0 ? DEFAULT_POOL_NAME : asyncPoolName[0];
+        return getMaxAsyncThreadSize(ForestConfiguration.configuration(), name);
     }
 
     /**
@@ -53,8 +54,9 @@ public class AsyncHttpExecutor<T> implements HttpExecutor {
      * @param configuration Forest配置对象
      * @return 最大异步线程数
      */
-    public static int getMaxAsyncThreadSize(ForestConfiguration configuration) {
-        final ThreadPoolExecutor pool = AsyncThreadPools.get(configuration);
+    public static int getMaxAsyncThreadSize(ForestConfiguration configuration, String... asyncPoolName) {
+        String name = asyncPoolName == null || asyncPoolName.length == 0 ? DEFAULT_POOL_NAME : asyncPoolName[0];
+        final ThreadPoolExecutor pool = AsyncThreadPools.get(configuration, name);
         if (pool == null) {
             return -1;
         }
@@ -68,8 +70,9 @@ public class AsyncHttpExecutor<T> implements HttpExecutor {
      * @return 异步线程池大小
      * @since 1.5.29
      */
-    public static int getAsyncThreadSize() {
-        return getAsyncThreadSize(ForestConfiguration.configuration());
+    public static int getAsyncThreadSize(String... asyncPoolName) {
+        String name = asyncPoolName == null || asyncPoolName.length == 0 ? DEFAULT_POOL_NAME : asyncPoolName[0];
+        return getAsyncThreadSize(ForestConfiguration.configuration(), name);
     }
 
     /**
@@ -79,8 +82,9 @@ public class AsyncHttpExecutor<T> implements HttpExecutor {
      * @return 异步线程池大小
      * @since 1.5.29
      */
-    public static int getAsyncThreadSize(ForestConfiguration configuration) {
-        final ThreadPoolExecutor pool = AsyncThreadPools.get(configuration);
+    public static int getAsyncThreadSize(ForestConfiguration configuration, String... asyncPoolName) {
+        String name = asyncPoolName == null || asyncPoolName.length == 0 ? DEFAULT_POOL_NAME : asyncPoolName[0];
+        final ThreadPoolExecutor pool = AsyncThreadPools.get(configuration, name);
         if (pool == null) {
             return -1;
         }
@@ -128,11 +132,20 @@ public class AsyncHttpExecutor<T> implements HttpExecutor {
 
     @Override
     public void execute(LifeCycleHandler lifeCycleHandler) {
-        final ThreadPoolExecutor pool = AsyncThreadPools.getOrCreate(configuration);
+        final ThreadPoolExecutor pool = AsyncThreadPools.getOrCreate(configuration, getRequestMethodAsyncPoolName());
         final AsyncTask<T> task = new AsyncTask<>(syncExecutor, lifeCycleHandler);
         final CompletableFuture<ForestResponse<T>> future = CompletableFuture.supplyAsync(task, pool);
         final ForestFuture<T> forestFuture = new ForestFuture<>(getRequest(), future);
         responseHandler.handleFuture(getRequest(), forestFuture);
+    }
+
+    public String getRequestMethodAsyncPoolName() {
+        ForestRequest<?> request = getRequest();
+        String asyncPoolName = request.getMethod().getMetaRequest().getAsyncPoolName();
+        if (StringUtils.isBlank(asyncPoolName)) {
+            return DEFAULT_POOL_NAME;
+        }
+        return asyncPoolName;
     }
 
     @Override
@@ -155,8 +168,8 @@ public class AsyncHttpExecutor<T> implements HttpExecutor {
      *
      * @since 1.5.23
      */
-    public static synchronized void closePool() {
-        final ThreadPoolExecutor pool = AsyncThreadPools.get(ForestConfiguration.configuration());
+    public static synchronized void closePool(String asyncPoolName) {
+        final ThreadPoolExecutor pool = AsyncThreadPools.get(ForestConfiguration.configuration(), asyncPoolName);
         if (pool != null) {
             pool.shutdown();
         }

--- a/forest-core/src/main/java/com/dtflys/forest/config/ForestConfiguration.java
+++ b/forest-core/src/main/java/com/dtflys/forest/config/ForestConfiguration.java
@@ -138,6 +138,12 @@ public class ForestConfiguration implements Serializable {
     private Integer maxRequestQueueSize;
 
     /**
+     * 多异步线程池配置
+     * Configuring multiple asynchronous thread pools
+     */
+    private Map<String,MultiAsyncPoolConfig> multiAsyncPoolConfig = new HashMap<>();
+
+    /**
      * 最大异步线程池大小
      */
     private Integer maxAsyncThreadSize;
@@ -364,7 +370,7 @@ public class ForestConfiguration implements Serializable {
      *
      * @since 1.5.29
      */
-    ThreadPoolExecutor asyncPool;
+    Map<String,ThreadPoolExecutor>  asyncPools = new HashMap<>();
 
 
     /**
@@ -454,6 +460,14 @@ public class ForestConfiguration implements Serializable {
      */
     public Map<Class, Object> getInstanceCache() {
         return instanceCache;
+    }
+
+    public Map<String, MultiAsyncPoolConfig> getMultiAsyncPoolConfig() {
+        return multiAsyncPoolConfig;
+    }
+
+    public void setMultiAsyncPoolConfig(Map<String, MultiAsyncPoolConfig> multiAsyncPoolConfig) {
+        this.multiAsyncPoolConfig = multiAsyncPoolConfig;
     }
 
     /**
@@ -2095,5 +2109,34 @@ public class ForestConfiguration implements Serializable {
                 .setUrl(url, args);
     }
 
+    /**
+     * 多异步线程池配置
+     */
+    public static class MultiAsyncPoolConfig {
+        /**
+         * Maximum number of async requests threads
+         */
+        private int maxAsyncThreadSize = 200;
 
+        /**
+         * Capacity of async requests queue
+         */
+        private int maxAsyncQueueSize = 100;
+
+        public int getMaxAsyncThreadSize() {
+            return maxAsyncThreadSize;
+        }
+
+        public void setMaxAsyncThreadSize(int maxAsyncThreadSize) {
+            this.maxAsyncThreadSize = maxAsyncThreadSize;
+        }
+
+        public int getMaxAsyncQueueSize() {
+            return maxAsyncQueueSize;
+        }
+
+        public void setMaxAsyncQueueSize(int maxAsyncQueueSize) {
+            this.maxAsyncQueueSize = maxAsyncQueueSize;
+        }
+    }
 }

--- a/forest-core/src/main/java/com/dtflys/forest/reflection/MetaRequest.java
+++ b/forest-core/src/main/java/com/dtflys/forest/reflection/MetaRequest.java
@@ -1,5 +1,6 @@
 package com.dtflys.forest.reflection;
 
+import com.dtflys.forest.config.ForestConfiguration;
 import com.dtflys.forest.converter.ForestConverter;
 import com.dtflys.forest.converter.ForestEncoder;
 import com.dtflys.forest.interceptor.Interceptor;
@@ -7,6 +8,7 @@ import com.dtflys.forest.logging.LogConfiguration;
 import com.dtflys.forest.utils.ForestDataType;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 public class MetaRequest {
 
@@ -40,6 +42,11 @@ public class MetaRequest {
      * whether can use async http request or not
      */
     private boolean async;
+
+    /**
+     * 指定异步线程池名称
+     */
+    private String asyncPoolName;
 
     /**
      * timeout
@@ -138,9 +145,12 @@ public class MetaRequest {
      */
     private LogConfiguration logConfiguration;
 
+
     public MetaRequest(Annotation requestAnnotation) {
         this.requestAnnotation = requestAnnotation;
     }
+
+
 
     public MetaRequest() {
     }
@@ -196,6 +206,14 @@ public class MetaRequest {
 
     public void setAsync(boolean async) {
         this.async = async;
+    }
+
+    public void setAsyncPoolName(String asyncPoolName) {
+        this.asyncPoolName = asyncPoolName;
+    }
+
+    public String getAsyncPoolName() {
+        return asyncPoolName;
     }
 
     public Integer getTimeout() {

--- a/forest-spring-boot-starter/src/main/java/com/dtflys/forest/springboot/ForestBeanRegister.java
+++ b/forest-spring-boot-starter/src/main/java/com/dtflys/forest/springboot/ForestBeanRegister.java
@@ -92,6 +92,7 @@ public class ForestBeanRegister implements ResourceLoaderAware, BeanPostProcesso
         }
 
         beanDefinitionBuilder
+                .addPropertyValue("multiAsyncPoolConfig",forestConfigurationProperties.getMultiAsyncPoolConfig())
                 .addPropertyValue("maxAsyncThreadSize", forestConfigurationProperties.getMaxAsyncThreadSize())
                 .addPropertyValue("maxAsyncQueueSize", forestConfigurationProperties.getMaxAsyncQueueSize())
                 .addPropertyValue("maxConnections", forestConfigurationProperties.getMaxConnections())

--- a/forest-spring-boot-starter/src/main/java/com/dtflys/forest/springboot/properties/ForestConfigurationProperties.java
+++ b/forest-spring-boot-starter/src/main/java/com/dtflys/forest/springboot/properties/ForestConfigurationProperties.java
@@ -3,6 +3,7 @@ package com.dtflys.forest.springboot.properties;
 import com.dtflys.forest.callback.AddressSource;
 import com.dtflys.forest.callback.RetryWhen;
 import com.dtflys.forest.callback.SuccessWhen;
+import com.dtflys.forest.config.ForestConfiguration;
 import com.dtflys.forest.http.ForestAsyncMode;
 import com.dtflys.forest.interceptor.Interceptor;
 import com.dtflys.forest.logging.DefaultLogHandler;
@@ -55,6 +56,12 @@ public class ForestConfigurationProperties {
      * Capacity of async requests queue
      */
     private int maxAsyncQueueSize = 100;
+
+    /**
+     * 多异步线程池配置
+     * Configuring multiple asynchronous thread pools
+     */
+    private Map<String, ForestConfiguration.MultiAsyncPoolConfig> multiAsyncPoolConfig = new HashMap<>();
 
     /**
      * Parallel mode of async requests
@@ -206,6 +213,37 @@ public class ForestConfigurationProperties {
 
     private Map<String, Class> filters = new HashMap<>();
 
+    /**
+     * 多异步线程池配置
+     */
+    public static class MultiAsyncPoolConfig {
+        /**
+         * Maximum number of async requests threads
+         */
+        private int maxAsyncThreadSize = 200;
+
+        /**
+         * Capacity of async requests queue
+         */
+        private int maxAsyncQueueSize = 100;
+
+        public int getMaxAsyncThreadSize() {
+            return maxAsyncThreadSize;
+        }
+
+        public void setMaxAsyncThreadSize(int maxAsyncThreadSize) {
+            this.maxAsyncThreadSize = maxAsyncThreadSize;
+        }
+
+        public int getMaxAsyncQueueSize() {
+            return maxAsyncQueueSize;
+        }
+
+        public void setMaxAsyncQueueSize(int maxAsyncQueueSize) {
+            this.maxAsyncQueueSize = maxAsyncQueueSize;
+        }
+    }
+
 /*
     public boolean isEnabled() {
         return enabled;
@@ -215,6 +253,13 @@ public class ForestConfigurationProperties {
         this.enabled = enabled;
     }
 */
+    public Map<String, ForestConfiguration.MultiAsyncPoolConfig> getMultiAsyncPoolConfig() {
+        return multiAsyncPoolConfig;
+    }
+
+    public void setMultiAsyncPoolConfig(Map<String, ForestConfiguration.MultiAsyncPoolConfig> multiAsyncPoolConfig) {
+        this.multiAsyncPoolConfig = multiAsyncPoolConfig;
+    }
 
     public String getBeanId() {
         return beanId;

--- a/forest-test/forest-spring-boot-test/src/test/java/com/dtflys/forest/springboot/test/multiPool/MultiPoolApi.java
+++ b/forest-test/forest-spring-boot-test/src/test/java/com/dtflys/forest/springboot/test/multiPool/MultiPoolApi.java
@@ -1,0 +1,26 @@
+package com.dtflys.forest.springboot.test.multiPool;
+
+import com.dtflys.forest.annotation.Delete;
+import com.dtflys.forest.annotation.Get;
+import com.dtflys.forest.annotation.Post;
+import com.dtflys.forest.annotation.Var;
+
+import java.util.concurrent.Future;
+
+public interface MultiPoolApi {
+
+    @Get(value = "https://forest.dtflyx.com/pages/1.5.36/spring_boot_config_items/", async = true,asyncPoolName = "high")
+    Future<String> highLevelRequest();
+
+
+    @Get(value = "https://forest.dtflyx.com/pages/1.5.36/spring_boot_config_items/", async = true,asyncPoolName = "normal")
+    Future<String> normalLevelRequest();
+
+    @Get(value = "https://forest.dtflyx.com/pages/1.5.36/spring_boot_config_items/", async = true,asyncPoolName = "fullTest")
+    Future<String> fullLevelRequest();
+
+    @Get(value = "https://forest.dtflyx.com/pages/1.5.36/spring_boot_config_items/", async = true)
+    Future<String> defaultLevelRequest();
+
+
+}

--- a/forest-test/forest-spring-boot-test/src/test/java/com/dtflys/forest/springboot/test/multiPool/MultiPoolTests.java
+++ b/forest-test/forest-spring-boot-test/src/test/java/com/dtflys/forest/springboot/test/multiPool/MultiPoolTests.java
@@ -1,0 +1,112 @@
+package com.dtflys.forest.springboot.test.multiPool;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author JingYu
+ * @date 2024/8/23 下午3:12
+ * 多线程池测试
+ */
+@RunWith(SpringRunner.class)
+@ActiveProfiles("multiPool")
+@SpringBootTest(classes = MultiPoolTests.class)
+@EnableAutoConfiguration
+public class MultiPoolTests {
+
+    private static final Logger log = LoggerFactory.getLogger(MultiPoolTests.class);
+    @Autowired
+    private MultiPoolApi multiPoolApi;
+
+    /**
+     * 多异步线程创建测试
+     * 执行流程：调用配置了：高、普通、默认 线程池http接口
+     * 预期：各个线程池可以创建成功，并打印日志
+     */
+    @Test
+    public void asyncPollCreate() throws ExecutionException, InterruptedException {
+        Future<String> stringForestRequest = multiPoolApi.highLevelRequest();
+        Future<String> normalLevelRequest = multiPoolApi.normalLevelRequest();
+        Future<String> defaultLevelRequest = multiPoolApi.defaultLevelRequest();
+        System.out.println(stringForestRequest.get());
+        System.out.println(normalLevelRequest.get());
+        System.out.println(defaultLevelRequest.get());
+
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 多请求等级测试
+     * 真实场景下可能会请求多个接口，每个接口的优先级不一
+     * 接口A优先级高，接口B优先级低
+     * 需要把接口A丢到更高级别的线程池中去执行
+     * 需要把接口B丢到普通级别的线程池中慢慢跑
+     * 测试流程：B接口执行多次，入队等待，A接口使用高优先级线程池执行
+     * 预期：AB接口互不影响、A接口运行结果穿插在普通接口中间执行
+     */
+    @Test
+    public void multiPoolLevelTest() throws InterruptedException {
+        // queueSize=5    maxThreadSize=5
+        new Thread(() -> {
+            for (int i = 0; i < 10; i++) {
+                new Thread(() -> {
+                    Future<String> normalLevelRequest = multiPoolApi.normalLevelRequest();
+                    try {
+                        normalLevelRequest.get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        throw new RuntimeException(e);
+                    }
+                    System.out.println("普通接口执行完成");
+                }).start();
+            }
+        }).start();
+
+        new Thread(() -> {
+            // queueSize=5    maxThreadSize=10
+            Future<String> highLevelRequest = multiPoolApi.highLevelRequest();
+            try {
+                highLevelRequest.get();
+                System.out.println("高优先接口执行完成");
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }).start();
+
+        TimeUnit.SECONDS.sleep(100);
+    }
+
+    /**
+     * 线程池打满测试
+     * 测试流程：创建大于线程池可处理任务总数的任务
+     * 预期：触发拒绝策略
+     */
+    @Test
+    public void asyncPoolFullTest() {
+        for (int i = 0; i < 10; i++) {
+            multiPoolApi.fullLevelRequest();
+            log.info("task {} 创建成功", i);
+        }
+
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/forest-test/forest-spring-boot-test/src/test/resources/application-multiPool.yml
+++ b/forest-test/forest-spring-boot-test/src/test/resources/application-multiPool.yml
@@ -1,0 +1,11 @@
+forest:
+  multi-async-pool-config:
+    high:
+      max-async-queue-size: 5
+      max-async-thread-size: 10
+    normal:
+      max-async-queue-size: 5
+      max-async-thread-size: 5
+    fullTest:
+      max-async-queue-size: 5
+      max-async-thread-size: 3


### PR DESCRIPTION
issues地址：https://github.com/dromara/forest/issues/204

主要变更：
1. 在@Get、@Post、@Delete、@Put、@Patch注解中新增了asyncPoolName的参数配置
2. 在ForestConfiguration、ForestConfigurationProperties 中新增了多异步线程池的配置项、新增asyncPools用于存储多异步线程池实例
3. 在AsyncHttpExecutor中新增多异步线程池的获取逻辑
4. 新增MultiPoolTests单元测试