### PR TITLE
fix: #173 修复Spring Boot 启动提示forest Bean Role问题

### DIFF
--- a/forest-spring-boot-starter/src/main/java/com/dtflys/forest/springboot/ForestAutoConfiguration.java
+++ b/forest-spring-boot-starter/src/main/java/com/dtflys/forest/springboot/ForestAutoConfiguration.java
@@ -7,6 +7,7 @@ import com.dtflys.forest.reflection.SpringForestObjectFactory;
 import com.dtflys.forest.spring.ForestBeanProcessor;
 import com.dtflys.forest.springboot.annotation.ForestScannerRegister;
 import com.dtflys.forest.springboot.properties.ForestConfigurationProperties;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -14,12 +15,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Role;
 
 import javax.annotation.Resource;
 
 @Configuration
 @EnableConfigurationProperties({ForestConfigurationProperties.class})
 @Import({ForestScannerRegister.class})
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class ForestAutoConfiguration {
 
     @Resource
@@ -27,18 +30,21 @@ public class ForestAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public SpringForestProperties forestProperties() {
         return new SpringForestProperties();
     }
 
     @Bean
     @ConditionalOnMissingBean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public SpringForestObjectFactory forestObjectFactory() {
         return new SpringForestObjectFactory();
     }
 
     @Bean
     @ConditionalOnMissingBean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public SpringInterceptorFactory forestInterceptorFactory() {
         return new SpringInterceptorFactory();
     }
@@ -47,6 +53,7 @@ public class ForestAutoConfiguration {
     @Bean
     @DependsOn("forestBeanProcessor")
     @ConditionalOnMissingBean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public ForestBeanRegister forestBeanRegister(SpringForestProperties properties,
                                                     SpringForestObjectFactory forestObjectFactory,
                                                     SpringInterceptorFactory forestInterceptorFactory,
@@ -64,6 +71,7 @@ public class ForestAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public ForestBeanProcessor forestBeanProcessor() {
         return new ForestBeanProcessor();
     }

--- a/forest-spring-boot-starter/src/main/java/com/dtflys/forest/springboot/ForestBeanRegister.java
+++ b/forest-spring-boot-starter/src/main/java/com/dtflys/forest/springboot/ForestBeanRegister.java
@@ -124,6 +124,7 @@ public class ForestBeanRegister implements ResourceLoaderAware, BeanPostProcesso
                 .addPropertyValue("variables", forestConfigurationProperties.getVariables())
                 .setLazyInit(false)
                 .setFactoryMethod("configuration")
+                .setRole(BeanDefinition.ROLE_INFRASTRUCTURE)
                 .addConstructorArgValue(id);
 
 
@@ -165,6 +166,7 @@ public class ForestBeanRegister implements ResourceLoaderAware, BeanPostProcesso
 
     public ConverterBeanListener registerConverterBeanListener(ForestConfiguration forestConfiguration) {
         BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.genericBeanDefinition(ConverterBeanListener.class);
+        beanDefinitionBuilder.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
         BeanDefinition beanDefinition = beanDefinitionBuilder.getRawBeanDefinition();
         beanDefinition.getPropertyValues().addPropertyValue("forestConfiguration", forestConfiguration);
         BeanDefinitionRegistry beanFactory = (BeanDefinitionRegistry) applicationContext.getBeanFactory();

--- a/forest-spring-boot3-starter/src/main/java/com/dtflys/forest/springboot/ForestAutoConfiguration.java
+++ b/forest-spring-boot3-starter/src/main/java/com/dtflys/forest/springboot/ForestAutoConfiguration.java
@@ -6,6 +6,7 @@ import com.dtflys.forest.reflection.SpringForestObjectFactory;
 import com.dtflys.forest.spring.ForestBeanProcessor;
 import com.dtflys.forest.springboot.annotation.ForestScannerRegister;
 import com.dtflys.forest.springboot.properties.ForestConfigurationProperties;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -13,27 +14,32 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Role;
 
 
 @Configuration
 @EnableConfigurationProperties({ForestConfigurationProperties.class})
 @Import({ForestScannerRegister.class})
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class ForestAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public SpringForestProperties forestProperties() {
         return new SpringForestProperties();
     }
 
     @Bean
     @ConditionalOnMissingBean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public SpringForestObjectFactory forestObjectFactory() {
         return new SpringForestObjectFactory();
     }
 
     @Bean
     @ConditionalOnMissingBean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public SpringInterceptorFactory forestInterceptorFactory() {
         return new SpringInterceptorFactory();
     }
@@ -42,6 +48,7 @@ public class ForestAutoConfiguration {
     @Bean
     @DependsOn("forestBeanProcessor")
     @ConditionalOnMissingBean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public ForestBeanRegister forestBeanRegister(ConfigurableApplicationContext applicationContext,
                                                  SpringForestProperties properties,
                                                  SpringForestObjectFactory forestObjectFactory,
@@ -60,6 +67,7 @@ public class ForestAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public ForestBeanProcessor forestBeanProcessor() {
         return new ForestBeanProcessor();
     }

--- a/forest-spring-boot3-starter/src/main/java/com/dtflys/forest/springboot/ForestBeanRegister.java
+++ b/forest-spring-boot3-starter/src/main/java/com/dtflys/forest/springboot/ForestBeanRegister.java
@@ -37,7 +37,6 @@ import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class ForestBeanRegister implements ResourceLoaderAware, BeanPostProcessor {
 
@@ -124,6 +123,7 @@ public class ForestBeanRegister implements ResourceLoaderAware, BeanPostProcesso
                 .addPropertyValue("variables", forestConfigurationProperties.getVariables())
                 .setLazyInit(false)
                 .setFactoryMethod("configuration")
+                .setRole(BeanDefinition.ROLE_INFRASTRUCTURE)
                 .addConstructorArgValue(id);
 
 
@@ -165,6 +165,7 @@ public class ForestBeanRegister implements ResourceLoaderAware, BeanPostProcesso
 
     public ConverterBeanListener registerConverterBeanListener(ForestConfiguration forestConfiguration) {
         BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.genericBeanDefinition(ConverterBeanListener.class);
+        beanDefinitionBuilder.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
         BeanDefinition beanDefinition = beanDefinitionBuilder.getRawBeanDefinition();
         beanDefinition.getPropertyValues().addPropertyValue("forestConfiguration", forestConfiguration);
         BeanDefinitionRegistry beanFactory = (BeanDefinitionRegistry) applicationContext.getBeanFactory();


### PR DESCRIPTION
Spring Boot3之前是`info`,3以后改为`warn`了,根本原因就是`role`未设置



close #173 