### PR TITLE
fix: 修复ForestResponse类中setResult改为Optional类型导致getResultOpt时判空一直不会生效。

### DIFF
--- a/forest-core/src/main/java/com/dtflys/forest/handler/ResultHandler.java
+++ b/forest-core/src/main/java/com/dtflys/forest/handler/ResultHandler.java
@@ -77,7 +77,7 @@ public class ResultHandler {
 
     public Object getResult(Optional<?> resultOpt, ForestRequest request, ForestResponse response, Type resultType, Class resultClass) {
         String optStringValue = null;
-        if (resultOpt != null) {
+        if (resultOpt != null && resultOpt.isPresent()) {
             if (Optional.class.isAssignableFrom(resultClass)) {
                 return resultOpt;
             }

--- a/forest-core/src/main/java/com/dtflys/forest/http/ForestResponse.java
+++ b/forest-core/src/main/java/com/dtflys/forest/http/ForestResponse.java
@@ -358,7 +358,7 @@ public abstract class ForestResponse<T> extends ResultGetter implements HasURL, 
      * @since 1.6.0
      */
     public Optional<T> getResultOpt() {
-        if (result == null && isReceivedResponseData()) {
+        if ((result == null || !result.isPresent()) && isReceivedResponseData()) {
             Type type = request.getLifeCycleHandler().getResultType();
             if (type == null) {
                 type = request.getMethod().getReturnType();
@@ -381,7 +381,7 @@ public abstract class ForestResponse<T> extends ResultGetter implements HasURL, 
                 }
             }
         }
-        return result == null ? Optional.empty() : result;
+        return result == null || !result.isPresent() ? Optional.empty() : result;
     }
     
     /**


### PR DESCRIPTION
1、已做兼容修复。
![image](https://github.com/user-attachments/assets/6485f399-2f20-4fff-8ecf-6deb4786cb1f)
![image](https://github.com/user-attachments/assets/61b2d9be-8ec3-4d54-9590-ed92b0cb4a55)
