### PR TITLE
fix: resolve BeanPostProcessors auto-proxy warning (#257)

### DIFF
--- a/forest-spring-boot-starter/src/main/java/com/dtflys/forest/springboot/ForestAutoConfiguration.java
+++ b/forest-spring-boot-starter/src/main/java/com/dtflys/forest/springboot/ForestAutoConfiguration.java
@@ -13,20 +13,14 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Role;
-
-import javax.annotation.Resource;
 
 @Configuration
 @EnableConfigurationProperties({ForestConfigurationProperties.class})
 @Import({ForestScannerRegister.class})
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class ForestAutoConfiguration {
-
-    @Resource
-    private ConfigurableApplicationContext applicationContext;
 
     @Bean
     @ConditionalOnMissingBean
@@ -51,28 +45,25 @@ public class ForestAutoConfiguration {
 
 
     @Bean
-    @DependsOn("forestBeanProcessor")
     @ConditionalOnMissingBean
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-    public ForestBeanRegister forestBeanRegister(SpringForestProperties properties,
-                                                    SpringForestObjectFactory forestObjectFactory,
-                                                    SpringInterceptorFactory forestInterceptorFactory,
-                                                    ForestConfigurationProperties forestConfigurationProperties) {
-        ForestBeanRegister register = new ForestBeanRegister(
+    public static ForestBeanRegister forestBeanRegister(ConfigurableApplicationContext applicationContext,
+                                                        SpringForestProperties properties,
+                                                        SpringForestObjectFactory forestObjectFactory,
+                                                        SpringInterceptorFactory forestInterceptorFactory,
+                                                        ForestConfigurationProperties forestConfigurationProperties) {
+        return new ForestBeanRegister(
                 applicationContext,
                 forestConfigurationProperties,
                 properties,
                 forestObjectFactory,
                 forestInterceptorFactory);
-        register.registerForestConfiguration();
-        register.registerScanner();
-        return register;
     }
 
     @Bean
     @ConditionalOnMissingBean
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-    public ForestBeanProcessor forestBeanProcessor() {
+    public static ForestBeanProcessor forestBeanProcessor() {
         return new ForestBeanProcessor();
     }
 

--- a/forest-spring-boot-starter/src/main/java/com/dtflys/forest/springboot/ForestBeanRegister.java
+++ b/forest-spring-boot-starter/src/main/java/com/dtflys/forest/springboot/ForestBeanRegister.java
@@ -18,11 +18,11 @@ import com.dtflys.forest.springboot.properties.ForestConverterItemProperties;
 import com.dtflys.forest.springboot.properties.ForestSSLKeyStoreProperties;
 import com.dtflys.forest.utils.ForestDataType;
 import com.dtflys.forest.utils.StringUtils;
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.cglib.core.ReflectUtils;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class ForestBeanRegister implements ResourceLoaderAware, BeanPostProcessor {
+public class ForestBeanRegister implements ResourceLoaderAware, BeanDefinitionRegistryPostProcessor {
 
     private final ConfigurableApplicationContext applicationContext;
 
@@ -69,6 +69,16 @@ public class ForestBeanRegister implements ResourceLoaderAware, BeanPostProcesso
     @Override
     public void setResourceLoader(ResourceLoader resourceLoader) {
         this.resourceLoader = resourceLoader;
+    }
+
+    @Override
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) {
+        registerForestConfiguration();
+        registerScanner();
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) {
     }
 
 
@@ -296,13 +306,4 @@ public class ForestBeanRegister implements ResourceLoaderAware, BeanPostProcesso
         return scanner;
     }
 
-    @Override
-    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
-        return bean;
-    }
-
-    @Override
-    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        return bean;
-    }
 }

--- a/forest-spring-boot3-starter/src/main/java/com/dtflys/forest/springboot/ForestAutoConfiguration.java
+++ b/forest-spring-boot3-starter/src/main/java/com/dtflys/forest/springboot/ForestAutoConfiguration.java
@@ -12,7 +12,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Role;
 
@@ -46,29 +45,25 @@ public class ForestAutoConfiguration {
 
 
     @Bean
-    @DependsOn("forestBeanProcessor")
     @ConditionalOnMissingBean
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-    public ForestBeanRegister forestBeanRegister(ConfigurableApplicationContext applicationContext,
-                                                 SpringForestProperties properties,
-                                                 SpringForestObjectFactory forestObjectFactory,
-                                                 SpringInterceptorFactory forestInterceptorFactory,
-                                                 ForestConfigurationProperties forestConfigurationProperties) {
-        ForestBeanRegister register = new ForestBeanRegister(
+    public static ForestBeanRegister forestBeanRegister(ConfigurableApplicationContext applicationContext,
+                                                        SpringForestProperties properties,
+                                                        SpringForestObjectFactory forestObjectFactory,
+                                                        SpringInterceptorFactory forestInterceptorFactory,
+                                                        ForestConfigurationProperties forestConfigurationProperties) {
+        return new ForestBeanRegister(
                 applicationContext,
                 forestConfigurationProperties,
                 properties,
                 forestObjectFactory,
                 forestInterceptorFactory);
-        register.registerForestConfiguration();
-        register.registerScanner();
-        return register;
     }
 
     @Bean
     @ConditionalOnMissingBean
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-    public ForestBeanProcessor forestBeanProcessor() {
+    public static ForestBeanProcessor forestBeanProcessor() {
         return new ForestBeanProcessor();
     }
 

--- a/forest-spring-boot3-starter/src/main/java/com/dtflys/forest/springboot/ForestBeanRegister.java
+++ b/forest-spring-boot3-starter/src/main/java/com/dtflys/forest/springboot/ForestBeanRegister.java
@@ -18,9 +18,9 @@ import com.dtflys.forest.springboot.properties.ForestConverterItemProperties;
 import com.dtflys.forest.springboot.properties.ForestSSLKeyStoreProperties;
 import com.dtflys.forest.utils.ForestDataType;
 import com.dtflys.forest.utils.StringUtils;
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.ManagedMap;
@@ -38,7 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-public class ForestBeanRegister implements ResourceLoaderAware, BeanPostProcessor {
+public class ForestBeanRegister implements ResourceLoaderAware, BeanDefinitionRegistryPostProcessor {
 
     private final ConfigurableApplicationContext applicationContext;
 
@@ -68,6 +68,16 @@ public class ForestBeanRegister implements ResourceLoaderAware, BeanPostProcesso
     @Override
     public void setResourceLoader(ResourceLoader resourceLoader) {
         this.resourceLoader = resourceLoader;
+    }
+
+    @Override
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) {
+        registerForestConfiguration();
+        registerScanner();
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) {
     }
 
 
@@ -294,13 +304,4 @@ public class ForestBeanRegister implements ResourceLoaderAware, BeanPostProcesso
         return scanner;
     }
 
-    @Override
-    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
-        return bean;
-    }
-
-    @Override
-    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        return bean;
-    }
 }

--- a/forest-test/forest-spring-boot3-test/src/test/java/com/dtflys/forest/springboot3/test/ForestAutoProxyWarningTest.java
+++ b/forest-test/forest-spring-boot3-test/src/test/java/com/dtflys/forest/springboot3/test/ForestAutoProxyWarningTest.java
@@ -1,0 +1,55 @@
+package com.dtflys.forest.springboot3.test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.dtflys.forest.springboot.annotation.ForestScannerRegister;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.event.ApplicationFailedEvent;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+
+import static org.junit.Assert.assertFalse;
+
+public class ForestAutoProxyWarningTest extends BaseSpringBootTest {
+
+    @Test
+    public void testNoBeanPostProcessorCheckerWarning() {
+        Logger logger = (Logger) LoggerFactory.getLogger(
+                "org.springframework.context.support.PostProcessorRegistrationDelegate$BeanPostProcessorChecker");
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        Level level = logger.getLevel();
+        logger.setLevel(Level.INFO);
+
+        try (ConfigurableApplicationContext ignored = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.NONE)
+                .listeners(event -> {
+                    if (event instanceof ApplicationFailedEvent) {
+                        ForestScannerRegister.cleanBackPackages();
+                    }
+                })
+                .run("--spring.main.banner-mode=off")) {
+            assertFalse(appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .anyMatch(message -> message.contains("not eligible for getting processed by all BeanPostProcessors")
+                            && message.contains("forestBeanProcessor")));
+        } finally {
+            logger.detachAppender(appender);
+            logger.setLevel(level);
+        }
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    @AutoConfigurationPackage
+    static class TestApplication {
+    }
+}


### PR DESCRIPTION
修复 Spring Boot 3.x 启动时的 BeanPostProcessors auto-proxy 警告（#257）
在 Spring Boot 3.4 / Spring 6.2 环境下，应用启动时会出现以下警告：
not eligible for getting processed by all BeanPostProcessors (for example: not eligible to auto-proxying).
Is this bean getting eagerly injected/applied to a currently created BeanPostProcessor [forestBeanProcessor]?

### 总结您的更改
调整 Bean 注册流程, 修复启动阶段的 BeanPostProcessors 警告, 同步修复 Boot2 Starter 中相同的问题, 保持行为一致.
最后新增回归测试, 验证启动时不再出现该警告. 

#### 请注明您已完成以下工作：

- [ ✓] 确保测试通过，并在需要时添加测试覆盖率。
- [ ✓] 确保提交消息遵循 [常规提交规范](https://www.conventionalcommits.org/) 的规则。
- [ ✓] 考虑文档的影响，如果需要，打开一个新的文档问题或文档更改的PR。