### PR TITLE
docs: fix Chinese typo 帐号 -> 账号 in comments

### DIFF
--- a/forest-core/src/main/java/com/dtflys/forest/lifecycles/authorization/OAuth2LifeCycle.java
+++ b/forest-core/src/main/java/com/dtflys/forest/lifecycles/authorization/OAuth2LifeCycle.java
@@ -71,7 +71,7 @@ public class OAuth2LifeCycle implements MethodAnnotationLifeCycle<OAuth2, Void> 
         if (StringUtils.isNotBlank(cacheId)) {
             return cacheId;
         }
-        // tokenUri/clientId/grantType/scope/username 任何一个变动都可能是不同的帐号权限
+        // tokenUri/clientId/grantType/scope/username 任何一个变动都可能是不同的账号权限
         final String tokenUri = getAttributeAsString(request, "tokenUri");
         final String clientId = getAttributeAsString(request, "clientId");
         final Object grantType = getAttribute(request, "grantType");
@@ -265,7 +265,7 @@ public class OAuth2LifeCycle implements MethodAnnotationLifeCycle<OAuth2, Void> 
      * @param clientId                 客户端ID
      * @param request                  请求对象
      * @param clientAuthentication     客户端认证模式：clientId/clientSecret 参数的传输模式
-     * @param fillAccount              是否填充帐号信息。该帐号信息在注解中设置
+     * @param fillAccount              是否填充账号信息。该账号信息在注解中设置
      * @return 返回请求参数
      */
     private Map<String, Object> createRequestBody(String clientId, ForestRequest request, OAuth2.ClientAuthentication clientAuthentication, boolean fillAccount) {


### PR DESCRIPTION
## Description
Fix Chinese typo `帐号` → `账号` in Java comments (2 occurrences).

File: `forest-core/src/main/java/com/dtflys/forest/lifecycles/authorization/OAuth2LifeCycle.java`

According to mainland Chinese language standards (`现代汉语词典`), `账号` is the correct form for "account".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>